### PR TITLE
Add: Global waiting cursor when fetching projects

### DIFF
--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -24,7 +24,7 @@ from osfoffline.sync.remote import RemoteSyncWorker
 logger = logging.getLogger(__name__)
 
 def waiting_effects(function):
-    @functools.wraps(function)
+    @wraps(function)
     def wrap(*args, **kwargs):
         QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         try:

--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -9,10 +9,10 @@ from PyQt5.QtWidgets import QDialog
 from PyQt5.QtWidgets import QFileDialog
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtWidgets import QTreeWidgetItem
-from PyQt5.QtWidgets import QApplication
 from sqlalchemy.orm.exc import NoResultFound
 
 from osfoffline import language
+from osfoffline.utils import waiting_effects
 from osfoffline.client.osf import OSFClient
 from osfoffline.database import Session
 from osfoffline.database.models import User, Node
@@ -149,7 +149,6 @@ class Preferences(QDialog, Ui_Settings):
 
             self._executor = QtCore.QThread()
             self.node_fetcher = NodeFetcher()
-            QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
             self.node_fetcher.finished[list].connect(self.populate_item_tree)
             self.node_fetcher.finished[int].connect(self.item_load_error)
             self.node_fetcher.moveToThread(self._executor)
@@ -182,7 +181,6 @@ class Preferences(QDialog, Ui_Settings):
 
         self.treeWidget.resizeColumnToContents(self.PROJECT_SYNC_COLUMN)
         self.treeWidget.resizeColumnToContents(self.PROJECT_NAME_COLUMN)
-        QApplication.restoreOverrideCursor()
 
     @QtCore.pyqtSlot(int)
     def item_load_error(self, error_code):
@@ -198,6 +196,9 @@ class Preferences(QDialog, Ui_Settings):
 class NodeFetcher(QtCore.QObject):
     finished = QtCore.pyqtSignal([list], [int])
 
+    
+
+    @waiting_effects
     def fetch(self):
         """Fetch the list of nodes associated with a user. Returns either a list, or an (int) error code."""
         try:

--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import QDialog
 from PyQt5.QtWidgets import QFileDialog
 from PyQt5.QtWidgets import QMessageBox
 from PyQt5.QtWidgets import QTreeWidgetItem
+from PyQt5.QtWidgets import QApplication
 from sqlalchemy.orm.exc import NoResultFound
 
 from osfoffline import language
@@ -148,12 +149,13 @@ class Preferences(QDialog, Ui_Settings):
 
             self._executor = QtCore.QThread()
             self.node_fetcher = NodeFetcher()
-            self.treeWidget.setCursor(QtCore.Qt.BusyCursor)
+            QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
             self.node_fetcher.finished[list].connect(self.populate_item_tree)
             self.node_fetcher.finished[int].connect(self.item_load_error)
             self.node_fetcher.moveToThread(self._executor)
             self._executor.started.connect(self.node_fetcher.fetch)
             self._executor.start()
+
 
     def reset_tree_widget(self):
         self.tree_items.clear()
@@ -180,7 +182,7 @@ class Preferences(QDialog, Ui_Settings):
 
         self.treeWidget.resizeColumnToContents(self.PROJECT_SYNC_COLUMN)
         self.treeWidget.resizeColumnToContents(self.PROJECT_NAME_COLUMN)
-        self.treeWidget.unsetCursor()
+        QApplication.restoreOverrideCursor()
 
     @QtCore.pyqtSlot(int)
     def item_load_error(self, error_code):

--- a/osfoffline/utils/__init__.py
+++ b/osfoffline/utils/__init__.py
@@ -1,9 +1,6 @@
 import hashlib
 import os
 
-from PyQt5 import QtCore
-from PyQt5.QtCore import QCoreApplication
-from PyQt5.QtWidgets import QApplication
 from sqlalchemy.orm.exc import NoResultFound
 
 from osfoffline import settings
@@ -91,15 +88,3 @@ def _remote_root(db):
             osf.NodeStorage.load(osf.OSFClient().request_session, db.node.id)
             if storage.provider == db.provider
     )
-
-def waiting_effects(function):
-        def wrap(*args, **kwargs):
-            QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
-            try:
-                function(*args, **kwargs)
-            except Exception as e:
-                logger.exception(e.args[0])
-                raise e
-            finally:
-                QApplication.restoreOverrideCursor()
-        return wrap

--- a/osfoffline/utils/__init__.py
+++ b/osfoffline/utils/__init__.py
@@ -1,6 +1,9 @@
 import hashlib
 import os
 
+from PyQt5 import QtCore
+from PyQt5.QtCore import QCoreApplication
+from PyQt5.QtWidgets import QApplication
 from sqlalchemy.orm.exc import NoResultFound
 
 from osfoffline import settings
@@ -88,3 +91,15 @@ def _remote_root(db):
             osf.NodeStorage.load(osf.OSFClient().request_session, db.node.id)
             if storage.provider == db.provider
     )
+
+def waiting_effects(function):
+        def wrap(*args, **kwargs):
+            QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
+            try:
+                function(*args, **kwargs)
+            except Exception as e:
+                logger.exception(e.args[0])
+                raise e
+            finally:
+                QApplication.restoreOverrideCursor()
+        return wrap


### PR DESCRIPTION
This makes the waiting cursor visible over all widgets as opposed to the hourglass that was just over the treewidget
[OFF-25]