### PR TITLE
remove read-only project from sync

### DIFF
--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -22,6 +22,18 @@ from osfoffline.sync.remote import RemoteSyncWorker
 logger = logging.getLogger(__name__)
 
 
+def get_parent_id(node):
+    try:
+        parent = node.raw['relationships']['parent']
+    except KeyError:
+        return None
+
+    data = parent['links']['related']['href'].split('/')
+
+    if data[-1]:
+        return data[-1]
+    return data[-2]
+
 class Preferences(QDialog, Ui_Settings):
     """
     This class is a wrapper for the Ui_Preferences and its controls
@@ -206,6 +218,10 @@ class NodeFetcher(QtCore.QObject):
             logger.exception('Error fetching list of nodes')
             result = -1
         else:
-            result = [node for node in user_nodes if 'parent' not in node.raw['relationships']]
+            nodes_id = [n.id for n in user_nodes]
+            result = []
+            for node in user_nodes:
+                if 'parent' not in node.raw['relationships'] or get_parent_id(node) not in nodes_id:
+                    result.append(node)
 
         self.finished[type(result)].emit(result)

--- a/osfoffline/settings/defaults.py
+++ b/osfoffline/settings/defaults.py
@@ -13,10 +13,10 @@ DEBUG = False
 DRY = False
 
 # Base URL for API server; used to fetch data
-OSF_URL = 'https://test.osf.io'
-API_BASE = 'https://test-api.osf.io'
+OSF_URL = 'https://staging.osf.io'
+API_BASE = 'https://staging-api.osf.io'
 API_VERSION = 'v2'
-FILE_BASE = 'https://test-files.osf.io'
+FILE_BASE = 'https://staging-files.osf.io'
 
 # Interval (in seconds) to poll the OSF for server-side file changes
 REMOTE_CHECK_INTERVAL = 60 * 5  # Every 5 minutes


### PR DESCRIPTION
<b>Purpose</b>
Remove the read only project from sync on the list. 

<b>Side effect</b>
The easy access permission api currently only exists on staging. And testing server is pointing to master. As a result change osf-sync to point to staging instead of testing.