### PR TITLE
Don't display Python Object in notification

### DIFF
--- a/osfoffline/tasks/operations.py
+++ b/osfoffline/tasks/operations.py
@@ -302,7 +302,7 @@ class RemoteDelete(BaseOperation):
             DatabaseDelete(
                 OperationContext(db=db_model)
             ).run()
-            Notification().info('Remote delete {}: {}'.format(db_model.kind.lower(), self.remote))
+            Notification().info('Remote delete {}: {}'.format(db_model.kind.lower(), self.remote.name))
 
 
 # Auditor looks for operations by specific names; DRY redundant implementations


### PR DESCRIPTION
Display the name of the file/dir deleted, not the object representation.

[OFF-93]