### PR TITLE
add timeouts to HTTP GETs

### DIFF
--- a/osfoffline/client/osf.py
+++ b/osfoffline/client/osf.py
@@ -66,7 +66,11 @@ class BaseResource(abc.ABC):
 
     @classmethod
     def load(cls, request_session, *args, **kwargs):
-        resp = request_session.get(cls.get_url(*args, **kwargs), params={'page[size]': 250})
+        resp = request_session.get(
+            cls.get_url(*args, **kwargs),
+            params={'page[size]': 250},
+            timeout=(settings.CONNECT_TIMEOUT, settings.READ_TIMEOUT),
+        )
         if resp.status_code >= 500:
             raise ClientLoadError(
                 resource=cls.RESOURCE,
@@ -85,7 +89,11 @@ class BaseResource(abc.ABC):
         if isinstance(data['data'], list):
             l = data['data']
             while data['links'].get('next'):
-                resp = request_session.get(data['links']['next'], params={'page[size]': 250})
+                resp = request_session.get(
+                    data['links']['next'],
+                    params={'page[size]': 250},
+                    timeout=(settings.CONNECT_TIMEOUT, settings.READ_TIMEOUT),
+                )
                 data = resp.json()
                 l.extend(data['data'])
             return [cls.from_data(request_session, item) for item in l]
@@ -112,7 +120,8 @@ class BaseResource(abc.ABC):
         params.update(query or {})
         resp = self.request_session.get(
             url,
-            params=params
+            params=params,
+            timeout=(settings.CONNECT_TIMEOUT, settings.READ_TIMEOUT),
         )
         data = resp.json()
         items = data['data']
@@ -196,7 +205,11 @@ class StorageObject(BaseResource):
 
     @classmethod
     def load(cls, request_session, *args):
-        resp = request_session.get(cls.get_url(*args), params={'page[size]': 250})
+        resp = request_session.get(
+            cls.get_url(*args),
+            params={'page[size]': 250},
+            timeout=(settings.CONNECT_TIMEOUT, settings.READ_TIMEOUT),
+        )
         data = resp.json()
 
         if 'errors' in data:

--- a/osfoffline/settings/defaults.py
+++ b/osfoffline/settings/defaults.py
@@ -27,6 +27,10 @@ INTERNET_CHECK_INTERVAL = 60
 # Time to keep alert messages on screen (in seconds); may not be configurable on all platforms
 ALERT_DURATION = 5.0  # sec
 
+# HTTP request timeouts
+CONNECT_TIMEOUT = 7
+READ_TIMEOUT = 10
+
 LOG_LEVEL = 'DEBUG'
 
 # sentry configuration. import from local

--- a/start.py
+++ b/start.py
@@ -50,7 +50,7 @@ def start():
     min_version = None
     # Then, if the current version is too old, close the program
     try:
-        r = requests.get(settings.MIN_VERSION_URL, timeout=10)
+        r = requests.get(settings.MIN_VERSION_URL, timeout=settings.READ_TIMEOUT)
     except requests.exceptions.ConnectionError:
         logger.warning('Check for minimum version requirements for OSF-Sync failed '
                        'because you have no Internet connection')


### PR DESCRIPTION
This should address SYNC-137.

The actual values might need to be tweaked.

Note that the “read” timeout is how long it will wait for data to _start_ coming in. A large response doesn’t have to _finish_ in that time.
