### PR TITLE
remove projects user no longer has access to

### DIFF
--- a/osfoffline/sync/remote.py
+++ b/osfoffline/sync/remote.py
@@ -139,6 +139,14 @@ class RemoteSyncWorker(threading.Thread, metaclass=Singleton):
                         "Remote Node<{}> appears to have been deleted; will stop tracking and delete from local database".format(
                             node.id))
                     return
+                elif err.status == http.client.FORBIDDEN:
+                    # access to this project removed?
+                    session.delete(node)
+                    session.commit()
+                    logger.info(
+                        "Access to Remote Node<{}> revoked; will stop tracking and delete from local database".format(
+                            node.id))
+                    return
                 else:  # TODO: maybe handle other statuses here
                     raise
             stack = remote_node.get_children(lazy=False)


### PR DESCRIPTION
This should address SYNC-125.

This also prevents a `ClientLoadError` on startup (which is probably why restarting the application didn’t fix the problem).

My concern is that there could be other (temporary) reasons for a 403 response. The only thing I could come up with is an incorrect password, but I think if you’re not logged in yet, the whole local database is empty anyway.
