### PR TITLE
tell Watchdog when the sync folder location changes

### DIFF
--- a/osfoffline/application/background.py
+++ b/osfoffline/application/background.py
@@ -64,3 +64,8 @@ class BackgroundHandler(metaclass=Singleton):
         del type(OperationWorker)._instances[OperationWorker]
         del type(RemoteSyncWorker)._instances[RemoteSyncWorker]
         del type(LocalSyncWorker)._instances[LocalSyncWorker]
+
+    def refresh(self):
+        logger.debug('Refreshing workers')
+        if LocalSyncWorker().is_alive():
+            LocalSyncWorker()._watch_folder()

--- a/osfoffline/gui/qt/preferences.py
+++ b/osfoffline/gui/qt/preferences.py
@@ -168,6 +168,7 @@ class Preferences(QDialog, Ui_Settings):
                 session.add(user)
                 session.commit()
             self.update_sync_nodes()
+            BackgroundHandler().refresh()
 
     def update_sync_nodes(self):
         self.selected_nodes = []

--- a/osfoffline/sync/local.py
+++ b/osfoffline/sync/local.py
@@ -23,6 +23,10 @@ class LocalSyncWorker(ConsolidatedEventHandler, metaclass=Singleton):
 
         self.ignore = threading.Event()
 
+        self.observer = Observer()
+        self._watch_folder(unschedule=False)
+
+    def _watch_folder(self, unschedule=True):
         try:
             user = get_current_user()
         except NoResultFound:
@@ -33,8 +37,9 @@ class LocalSyncWorker(ConsolidatedEventHandler, metaclass=Singleton):
             # it from happening.
             raise
         self.folder = user.folder
-
-        self.observer = Observer()
+        if unschedule:
+            self.observer.unschedule_all()
+        logger.debug('Setting observed path to {}'.format(self.folder))
         self.observer.schedule(self, self.folder, recursive=True)
 
     def start(self):


### PR DESCRIPTION
This should address SYNC-123.

Basically, when the path is changed via the preferences, watchdog is told to stop watching everything, then told to watch the new path.
