### PR TITLE
_diff tests and circular import fix

### DIFF
--- a/osfoffline/sync/ext/auditor.py
+++ b/osfoffline/sync/ext/auditor.py
@@ -10,6 +10,7 @@ from osfoffline.database import Session
 from osfoffline.database.models import Node, File
 from osfoffline.tasks import operations
 from osfoffline.tasks.operations import OperationContext
+from osfoffline.utils import EventType
 from osfoffline.utils import hash_file
 from osfoffline.utils import is_ignored
 from osfoffline.utils.authentication import get_current_user
@@ -20,13 +21,6 @@ logger = logging.getLogger(__name__)
 class Location(Enum):
     LOCAL = 0
     REMOTE = 1
-
-
-class EventType(Enum):
-    CREATE = 0
-    DELETE = 1
-    MOVE = 2
-    UPDATE = 3
 
 
 # Meant to emulate the watchdog FileSystemEvent

--- a/osfoffline/sync/remote.py
+++ b/osfoffline/sync/remote.py
@@ -19,13 +19,13 @@ from osfoffline.sync.local import LocalSyncWorker
 from osfoffline.sync.exceptions import FolderNotInFileSystem
 from osfoffline.sync.ext.auditor import (
     Auditor,
-    EventType
 )
 
 from osfoffline.tasks.notifications import Notification
 from osfoffline.tasks.resolution import RESOLUTION_MAP
 from osfoffline.tasks.queue import OperationWorker
 
+from osfoffline.utils import EventType
 from osfoffline.utils import Singleton
 from osfoffline.utils.authentication import get_current_user
 

--- a/osfoffline/tasks/interventions.py
+++ b/osfoffline/tasks/interventions.py
@@ -4,8 +4,8 @@ import logging
 import threading
 
 from osfoffline.tasks import operations
+from osfoffline.utils import EventType
 from osfoffline.utils import Singleton
-from osfoffline.sync.ext.auditor import EventType
 
 logger = logging.getLogger(__name__)
 

--- a/osfoffline/tasks/resolution.py
+++ b/osfoffline/tasks/resolution.py
@@ -2,9 +2,9 @@ import os
 
 from osfoffline.tasks import operations
 from osfoffline.database import Session
-from osfoffline.sync.ext.auditor import EventType
 from osfoffline.tasks import interventions
 from osfoffline.tasks.interventions import Intervention
+from osfoffline.utils import EventType
 from osfoffline.utils import hash_file
 
 

--- a/osfoffline/utils/__init__.py
+++ b/osfoffline/utils/__init__.py
@@ -2,6 +2,7 @@ import re
 import hashlib
 import os
 
+from enum import Enum
 from sqlalchemy.orm.exc import NoResultFound
 
 from osfoffline import settings
@@ -12,6 +13,13 @@ from osfoffline.utils.authentication import get_current_user
 
 
 IGNORE_RE = re.compile(r'.*{}({})'.format(re.escape(os.path.sep), '|'.join(settings.IGNORED_PATTERNS)))
+
+
+class EventType(Enum):
+    CREATE = 0
+    DELETE = 1
+    MOVE = 2
+    UPDATE = 3
 
 
 class Singleton(type):

--- a/tests/sync/test_auditor.py
+++ b/tests/sync/test_auditor.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from osfoffline.sync.ext.auditor import Audit
+from osfoffline.sync.ext.auditor import Auditor
+from osfoffline.utils import EventType
+
+from tests.base import OSFOTestBase
+
+
+diff = Auditor._diff
+# _diff never refers to self, so we'll always pass None as the fisrt argument
+
+diff_dict = {
+    '/file/path/as/string': Audit('fid', 'sha256', Path('/')),
+}
+base_path = Path('/fake/location/on/disk')
+mock_paths = (
+    base_path / 'README.md',
+    base_path / 'data',
+    base_path / 'data' / 'truth.csv',
+    base_path / 'data' / 'lies.csv',
+    base_path / 'data' / 'numbers.csv',
+    base_path / 'data' / 'words.txt',
+)
+
+def tree_with_indexes(*idx):
+    tree = {}
+    for i in idx:
+        path = mock_paths[i]
+        tree[str(path)] = Audit(i, 'sha256-hash-' + str(i), path)
+    return tree
+
+
+class TestAuditor(OSFOTestBase):
+
+    def test_diff(self):
+        left = tree_with_indexes(0, 1, 2, 3, 4, 5)
+        right = tree_with_indexes(0, 1, 2, 4, 5)
+        # one file removed
+        changes = diff(None, left, right)
+        assert len(changes[EventType.MOVE]) == 0
+        assert len(changes[EventType.CREATE]) == 1
+        assert len(changes[EventType.UPDATE]) == 0
+        assert len(changes[EventType.DELETE]) == 0
+        assert str(mock_paths[3]) in changes[EventType.CREATE]
+        # one file added
+        changes = diff(None, right, left)
+        assert len(changes[EventType.MOVE]) == 0
+        assert len(changes[EventType.CREATE]) == 0
+        assert len(changes[EventType.UPDATE]) == 0
+        assert len(changes[EventType.DELETE]) == 1
+        assert str(mock_paths[3]) in changes[EventType.DELETE]
+        # two files removed
+        right = tree_with_indexes(1, 2, 4, 5)
+        changes = diff(None, left, right)
+        assert len(changes[EventType.MOVE]) == 0
+        assert len(changes[EventType.CREATE]) == 2
+        assert len(changes[EventType.UPDATE]) == 0
+        assert len(changes[EventType.DELETE]) == 0
+        assert str(mock_paths[0]) in changes[EventType.CREATE]
+        assert str(mock_paths[3]) in changes[EventType.CREATE]


### PR DESCRIPTION
This is a start toward testing `Auditor._diff` as mentioned in #129 

It also contains a fix for a circular import that was revealed when trying to import from `auditor.py`.

FYI, I merged the code from #129 into a new branch and resolved the conflicts.

https://github.com/sixfeetup/osf-sync/tree/filenames
